### PR TITLE
Add ability to alias commands

### DIFF
--- a/lib/spurious/app.rb
+++ b/lib/spurious/app.rb
@@ -35,7 +35,7 @@ module Spurious
           }
         }
       methods.each do |meth, options|
-        desc meth.to_s, "#{meth} for the spurious containers"
+        desc meth.to_s, "#{meth} the spurious containers"
         define_method(meth) do
           event_loop meth
         end


### PR DESCRIPTION
I've currently added the same aliases that boot2docker uses as per the feature request from #7 

![](http://media.giphy.com/media/GQCjmHAlMuFuE/giphy.gif)
