### PR TITLE
Add rake spec task and make default task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,6 @@
 require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new do |task|
+  task.rspec_opts = ['--color', '--format', 'doc', '--format=Nc']
+end

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require "bundler/gem_tasks"
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new do |task|
-  task.rspec_opts = ['--color', '--format', 'doc', '--format=Nc']
+  task.rspec_opts = ['--color', '--format', 'doc']
 end
 
 task :default => :spec

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new do |task|
   task.rspec_opts = ['--color', '--format', 'doc', '--format=Nc']
 end
+
+task :default => :spec


### PR DESCRIPTION
I've got a branch for Travis-CI setup and one of the errors it throws is because there is no default rake task defined.

I thought I'd add the spec task as the default. We could even have it build/install the gem if the tests pass as default.

[Link to Travis-CI job](https://travis-ci.org/JakeChampion/spurious/jobs/35003878)
