### PR TITLE
[READY] Removes docker dep from CLI as part of server

### DIFF
--- a/spurious.gemspec
+++ b/spurious.gemspec
@@ -18,9 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "docker"
-  spec.add_runtime_dependency "docker-api"
-
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
Removes `docker` and `docker-api` dependencies as these are required by [spurious-server](https://www.github.com/stevenjack/spurious-server) which is already a dependency of this gem.
