### PR TITLE
Lock timeout gem version in gemspec

### DIFF
--- a/spurious.gemspec
+++ b/spurious.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "thor"
   spec.add_runtime_dependency "spurious-server"
   spec.add_runtime_dependency "eventmachine"
-  spec.add_runtime_dependency "timeout"
+  spec.add_runtime_dependency "timeout", "0.0.0"
 end


### PR DESCRIPTION
Resolves this error, which is due to changes in the 'timeout' gem since 0.0.0.

```
/Users/josephwynn/.rbenv/versions/2.2.0/lib/ruby/2.2.0/resolv.rb:161:in `<class:Resolv>': uninitialized constant Timeout::Error (NameError)
    from /Users/josephwynn/.rbenv/versions/2.2.0/lib/ruby/2.2.0/resolv.rb:36:in `<top (required)>'
    from /Users/josephwynn/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/josephwynn/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/josephwynn/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/eventmachine-1.0.4/lib/eventmachine.rb:39:in `<top (required)>'
    from /Users/josephwynn/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/josephwynn/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/josephwynn/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/spurious-0.4.1/lib/spurious/app.rb:2:in `<top (required)>'
    from /Users/josephwynn/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/josephwynn/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/josephwynn/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/spurious-0.4.1/bin/spurious:6:in `<top (required)>'
    from /Users/josephwynn/.rbenv/versions/2.2.0/bin/spurious:23:in `load'
    from /Users/josephwynn/.rbenv/versions/2.2.0/bin/spurious:23:in `<main>'
```
